### PR TITLE
Remove old permission handling

### DIFF
--- a/src/handler/guild/role.ts
+++ b/src/handler/guild/role.ts
@@ -1,11 +1,7 @@
 import { SlashCommandBuilder } from "@discordjs/builders";
 import { CommandInteraction, Guild, MessageEmbed } from "discord.js";
 
-import {
-    Command,
-    CommandData,
-    EventHandler,
-} from "../../decorators";
+import { Command, CommandData, EventHandler } from "../../decorators";
 import { BotError } from "../../error";
 import { guildCommandsData } from "../../decorators/data";
 


### PR DESCRIPTION
with this change the bot admin role is basically useless, but ideally we could automatically setup the permissions when it setup with the /role command.

however discord js hasnt released the changes for permissions v2 yet and a workaround doesnt seem worthwhile when the permissions can just be managed manually for now. 

this at least makes the bot usable again

