### PR TITLE
fixed verify messages arriving out of order

### DIFF
--- a/src/handler/guild/verifyAll.ts
+++ b/src/handler/guild/verifyAll.ts
@@ -85,16 +85,14 @@ export class VerifyAll {
                 member,
                 Color.GREEN
             );
-            logChannel.send({ embeds: [embed] });
+            await logChannel.send({ embeds: [embed] });
         }
 
-        {
-            const embed = new MessageEmbed()
-                .setDescription("Finished!")
-                .setColor(Color.GREEN);
+        const embed = new MessageEmbed()
+            .setDescription("Finished!")
+            .setColor(Color.GREEN);
 
-            await interaction.followUp({ embeds: [embed] });
-        }
+        await interaction.followUp({ embeds: [embed] });
     }
 }
 


### PR DESCRIPTION
when using `/verify-all` the follow up completion message is usually sent before the last verification message. This PR addresses that issue.