### PR TITLE
fix notifications typings in order to account for inconsistency in the api

### DIFF
--- a/src/wrapper/models/notification.ts
+++ b/src/wrapper/models/notification.ts
@@ -18,7 +18,7 @@ export const Training = t.type({
     }),
     endTime: t.number,
     hasUpdated: t.boolean,
-    currentlyTraining: t.number,
+    currentlyTraining: t.union([t.string, t.number]),
     queued: t.array(QueuedTrain),
     serverTime: t.number,
 });


### PR DESCRIPTION
`currentTraining` can be `string` or `number`